### PR TITLE
Add new methods and cover all possible desktop systems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ categories = [
 "zbus" = "3.1.0"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]
-version = '0.41.0'
+version = '0.42.0'
 features = [
     'Win32_Foundation',
     'Win32_Security',

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = 'system_shutdown'
-version = '3.0.2'
+version = '4.0.0'
 authors = ['Silvio Clecio (silvioprog) <silvioprog@gmail.com>']
 license = 'MIT/Apache-2.0'
 description = 'Rust library for shut down, reboot or log out operations.'
 homepage = 'https://github.com/risoflora/system_shutdown'
 repository = 'https://github.com/risoflora/system_shutdown'
 readme = 'README.md'
+edition = '2021'
 keywords = [
     'system',
     'shutdown',
@@ -20,16 +21,18 @@ categories = [
     'os::windows-apis',
 ]
 
-[dependencies]
-[target."cfg(windows)".dependencies.winapi]
-version = '0.3'
+[target.'cfg(target_os = "linux")'.dependencies]
+"zbus" = "2.3.2"
+
+[target.'cfg(target_os = "windows")'.dependencies.windows]
+version = '0.39.0'
 features = [
-    'errhandlingapi',
-    'processthreadsapi',
-    'reason',
-    'securitybaseapi',
-    'winbase',
-    'winerror',
-    'winnt',
-    'winuser',
+    'Win32_Foundation',
+    'Win32_Security',
+    'Win32_System_Com',
+    'Win32_System_Threading',
+    'Win32_System_Shutdown',
+    'Win32_System_Power',
+    'Win32_System_SystemServices',
+    'Win32_UI_WindowsAndMessaging'
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ categories = [
 "zbus" = "3.0.0"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]
-version = '0.39.0'
+version = '0.40.0'
 features = [
     'Win32_Foundation',
     'Win32_Security',

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ categories = [
 ]
 
 [target.'cfg(target_os = "linux")'.dependencies]
-"zbus" = "3.0.0"
+"zbus" = "3.1.0"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]
-version = '0.40.0'
+version = '0.41.0'
 features = [
     'Win32_Foundation',
     'Win32_Security',

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 ]
 
 [target.'cfg(target_os = "linux")'.dependencies]
-"zbus" = "2.3.2"
+"zbus" = "3.0.0"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]
 version = '0.39.0'

--- a/README.md
+++ b/README.md
@@ -43,13 +43,7 @@ Add this to your `Cargo.toml`:
 
 ```ini
 [dependencies]
-system_shutdown = "3.0.0"
-```
-
-and this to your crate root:
-
-```rust
-extern crate system_shutdown;
+system_shutdown = "4.0.0"
 ```
 
 ## Contributions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,6 @@
 //! The example below shows how to shut down the machine:
 //!
 //! ```rust
-//! extern crate system_shutdown;
-//!
 //! use system_shutdown::shutdown;
 //!
 //! fn main() {
@@ -21,16 +19,21 @@
 //!
 //! In most of the systems it does not requires the user to be root/admin.
 
-#[cfg(target_os = "windows")]
-extern crate winapi;
-
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(target_os = "linux")]
 #[path = "linux.rs"]
 mod os;
+
+#[cfg(target_os = "macos")]
+#[path = "macos.rs"]
+mod os;
+#[cfg(target_os = "macos")]
+pub use os::request_permission_dialog;
 
 #[cfg(target_os = "windows")]
 #[path = "windows.rs"]
 mod os;
+#[cfg(target_os = "windows")]
+pub use os::{shutdown_with_message, reboot_with_message};
 
 use std::io;
 
@@ -76,4 +79,14 @@ pub fn logout() -> ShutdownResult {
 /// Calls the OS-specific function to force to log out the user.
 pub fn force_logout() -> ShutdownResult {
     os::force_logout()
+}
+
+/// Calls the OS-specific function to put the machine to sleep.
+pub fn sleep() -> ShutdownResult {
+    os::sleep()
+}
+
+/// Calls the OS-specific function to hibernate the machine.
+pub fn hibernate() -> ShutdownResult {
+    os::hibernate()
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -44,29 +44,35 @@ fn run_command(command: &str, args: &[&str]) -> ShutdownResult {
 }
 
 fn get_session_id() -> String {
-    let mut session = std::fs::read_to_string("/proc/self/sessionid").unwrap_or_default().trim().to_string();
+    let mut session = std::env::var("XDG_SESSION_ID").unwrap_or_default();
     if session.is_empty() {
-        session = std::env::var("XDG_SESSION_ID").unwrap_or_default();
+        session = std::fs::read_to_string("/proc/self/sessionid").unwrap_or_default().trim().to_string();
     }
     session
 }
 
 /// Linux specific function to shut down the machine using the D-BUS method call.
 /// The following D-BUS calls are attempted:
-/// - org.freedesktop.login1.Manager.PowerOff(false)
+/// - org.gnome.SessionManager.Shutdown()
+/// - org.kde.KSMServerInterface.logout(-1, 2, 2)
+/// - org.xfce.SessionManager.Shutdown(true)
+/// - org.freedesktop.login1.Manager.PowerOff(true)
 /// - org.freedesktop.PowerManagement.Shutdown()
 /// - org.freedesktop.SessionManagement.Shutdown()
 /// - org.freedesktop.ConsoleKit.Manager.Stop()
 /// - org.freedesktop.Hal.Device.SystemPowerManagement.Shutdown()
-/// - org.gnome.SessionManager.Shutdown()
+/// - org.freedesktop.systemd1.Manager.PowerOff()
 /// If nothing works up to this point, as a last resort this function calls `shutdown -h now`
 pub fn shutdown() -> ShutdownResult {
-    if dbus_send("org.freedesktop.login1",            "/org/freedesktop/login1",               "org.freedesktop.login1.Manager",                   "PowerOff", &(false)) { return Ok(()); } // interactive - false
-    if dbus_send("org.freedesktop.PowerManagement",   "/org/freedesktop/PowerManagement",      "org.freedesktop.PowerManagement",                  "Shutdown",  &()) { return Ok(()); }
-    if dbus_send("org.freedesktop.SessionManagement", "/org/freedesktop/SessionManagement",    "org.freedesktop.SessionManagement",                "Shutdown",  &()) { return Ok(()); }
-    if dbus_send("org.freedesktop.ConsoleKit",        "/org/freedesktop/ConsoleKit/Manager",   "org.freedesktop.ConsoleKit.Manager",               "Stop",     &()) { return Ok(()); }
-    if dbus_send("org.freedesktop.Hal",               "/org/freedesktop/Hal/devices/computer", "org.freedesktop.Hal.Device.SystemPowerManagement", "Shutdown", &()) { return Ok(()); }
-    if dbus_send("org.gnome.SessionManager",          "/org/gnome/SessionManager",             "org.gnome.SessionManager",                         "Shutdown", &()) { return Ok(()); }
+    if dbus_send("org.gnome.SessionManager",          "/org/gnome/SessionManager",             "org.gnome.SessionManager",                         "Shutdown", &())         { return Ok(()); }
+    if dbus_send("org.kde.ksmserver",                 "/KSMServer",                            "org.kde.KSMServerInterface",                       "logout",   &(-1, 2, 2)) { return Ok(()); }
+    if dbus_send("org.xfce.SessionManager",           "/org/xfce/SessionManager",              "org.xfce.SessionManager",                          "Shutdown", &(true))     { return Ok(()); } // allow_save - true
+    if dbus_send("org.freedesktop.login1",            "/org/freedesktop/login1",               "org.freedesktop.login1.Manager",                   "PowerOff", &(true))     { return Ok(()); } // interactive - true
+    if dbus_send("org.freedesktop.PowerManagement",   "/org/freedesktop/PowerManagement",      "org.freedesktop.PowerManagement",                  "Shutdown", &())         { return Ok(()); }
+    if dbus_send("org.freedesktop.SessionManagement", "/org/freedesktop/SessionManagement",    "org.freedesktop.SessionManagement",                "Shutdown", &())         { return Ok(()); }
+    if dbus_send("org.freedesktop.ConsoleKit",        "/org/freedesktop/ConsoleKit/Manager",   "org.freedesktop.ConsoleKit.Manager",               "Stop",     &())         { return Ok(()); }
+    if dbus_send("org.freedesktop.Hal",               "/org/freedesktop/Hal/devices/computer", "org.freedesktop.Hal.Device.SystemPowerManagement", "Shutdown", &())         { return Ok(()); }
+    if dbus_send("org.freedesktop.systemd1",          "/org/freedesktop/systemd1",             "org.freedesktop.systemd1.Manager",                 "PowerOff", &())         { return Ok(()); }
 
     // As a last resort
     run_command("shutdown", &["-h", "now"])
@@ -79,20 +85,26 @@ pub fn force_shutdown() -> ShutdownResult {
 
 /// Linux specific function to reboot the machine using the D-BUS method call.
 /// The following D-BUS calls are attempted:
-/// - org.freedesktop.login1.Manager.Reboot(false)
+/// - org.gnome.SessionManager.Reboot()
+/// - org.kde.KSMServerInterface.logout(-1, 1, 2)
+/// - org.xfce.SessionManager.Restart(true)
+/// - org.freedesktop.login1.Manager.Reboot(true)
 /// - org.freedesktop.PowerManagement.Reboot()
 /// - org.freedesktop.SessionManagement.Reboot()
 /// - org.freedesktop.ConsoleKit.Manager.Restart()
 /// - org.freedesktop.Hal.Device.SystemPowerManagement.Reboot()
-/// - org.gnome.SessionManager.Reboot()
+/// - org.freedesktop.systemd1.Manager.Reboot()
 /// If nothing works up to this point, as a last resort this function calls `shutdown -r now`
 pub fn reboot() -> ShutdownResult {
-    if dbus_send("org.freedesktop.login1",            "/org/freedesktop/login1",               "org.freedesktop.login1.Manager",                   "Reboot",  &(false)) { return Ok(()); } // interactive - false
-    if dbus_send("org.freedesktop.PowerManagement",   "/org/freedesktop/PowerManagement",      "org.freedesktop.PowerManagement",                  "Reboot",  &()) { return Ok(()); }
-    if dbus_send("org.freedesktop.SessionManagement", "/org/freedesktop/SessionManagement",    "org.freedesktop.SessionManagement",                "Reboot",  &()) { return Ok(()); }
-    if dbus_send("org.freedesktop.ConsoleKit",        "/org/freedesktop/ConsoleKit/Manager",   "org.freedesktop.ConsoleKit.Manager",               "Restart", &()) { return Ok(()); }
-    if dbus_send("org.freedesktop.Hal",               "/org/freedesktop/Hal/devices/computer", "org.freedesktop.Hal.Device.SystemPowerManagement", "Reboot",  &()) { return Ok(()); }
-    if dbus_send("org.gnome.SessionManager",          "/org/gnome/SessionManager",             "org.gnome.SessionManager",                         "Reboot",  &()) { return Ok(()); }
+    if dbus_send("org.gnome.SessionManager",          "/org/gnome/SessionManager",             "org.gnome.SessionManager",                         "Reboot",  &())         { return Ok(()); }
+    if dbus_send("org.kde.ksmserver",                 "/KSMServer",                            "org.kde.KSMServerInterface",                       "logout",  &(-1, 1, 2)) { return Ok(()); }
+    if dbus_send("org.xfce.SessionManager",           "/org/xfce/SessionManager",              "org.xfce.SessionManager",                          "Restart", &(true))     { return Ok(()); } // allow_save - true
+    if dbus_send("org.freedesktop.login1",            "/org/freedesktop/login1",               "org.freedesktop.login1.Manager",                   "Reboot",  &(true))     { return Ok(()); } // interactive - true
+    if dbus_send("org.freedesktop.PowerManagement",   "/org/freedesktop/PowerManagement",      "org.freedesktop.PowerManagement",                  "Reboot",  &())         { return Ok(()); }
+    if dbus_send("org.freedesktop.SessionManagement", "/org/freedesktop/SessionManagement",    "org.freedesktop.SessionManagement",                "Reboot",  &())         { return Ok(()); }
+    if dbus_send("org.freedesktop.ConsoleKit",        "/org/freedesktop/ConsoleKit/Manager",   "org.freedesktop.ConsoleKit.Manager",               "Restart", &())         { return Ok(()); }
+    if dbus_send("org.freedesktop.Hal",               "/org/freedesktop/Hal/devices/computer", "org.freedesktop.Hal.Device.SystemPowerManagement", "Reboot",  &())         { return Ok(()); }
+    if dbus_send("org.freedesktop.systemd1",          "/org/freedesktop/systemd1",             "org.freedesktop.systemd1.Manager",                 "Reboot",  &())         { return Ok(()); }
 
     // As a last resort
     run_command("shutdown", &["-r", "now"])
@@ -110,17 +122,22 @@ pub fn force_reboot() -> ShutdownResult {
 
 /// Linux specific function to log out the user using the D-BUS method call.
 /// The following D-BUS calls are attempted:
-/// - org.freedesktop.login1.Manager.TerminateSession(session_id)
 /// - org.gnome.SessionManager.Logout(1)
+/// - org.kde.KSMServerInterface.logout(-1, 0, 2)
 /// - org.kde.KSMServerInterface.closeSession()
+/// - org.xfce.SessionManager.Logout(true, true)
+/// - org.freedesktop.login1.Manager.TerminateSession(session_id)
 /// If nothing works up to this point, as a last resort this function calls `loginctl kill-session $XDG_SESSION_ID`
 pub fn logout() -> ShutdownResult {
+    if dbus_send("org.gnome.SessionManager",  "/org/gnome/SessionManager",  "org.gnome.SessionManager",       "Logout",           &(1))           { return Ok(()); } // 1 - no confirmation dialog, 2 - force logout
+    if dbus_send("org.kde.ksmserver",         "/KSMServer",                 "org.kde.KSMServerInterface",     "logout",           &(-1, 0, 2))    { return Ok(()); }
+    if dbus_send("org.kde.ksmserver",         "/KSMServer",                 "org.kde.KSMServerInterface",     "closeSession",     &())            { return Ok(()); }
+    if dbus_send("org.xfce.SessionManager",   "/org/xfce/SessionManager",   "org.xfce.SessionManager",        "Logout",           &(true, true))  { return Ok(()); } // show_dialog - true, allow_save - true
+
     let session_id = get_session_id();
     if !session_id.is_empty() {
-        if dbus_send("org.freedesktop.login1",    "/org/freedesktop/login1",    "org.freedesktop.login1.Manager", "TerminateSession", &(session_id)) { return Ok(()); }
+        if dbus_send("org.freedesktop.login1", "/org/freedesktop/login1", "org.freedesktop.login1.Manager", "TerminateSession", &(session_id)) { return Ok(()); }
     }
-    if dbus_send("org.gnome.SessionManager",  "/org/gnome/SessionManager",  "org.gnome.SessionManager",       "Logout",           &(1)) { return Ok(()); } // 1 - no confirmation dialog, 2 - force logout
-    if dbus_send("org.kde.ksmserver",         "/KSMServer",                 "org.kde.KSMServerInterface",     "closeSession",     &())  { return Ok(()); }
 
     // As a last resort
     run_command("loginctl", &["kill-session", &session_id])
@@ -133,14 +150,16 @@ pub fn force_logout() -> ShutdownResult {
 
 /// Linux specific function to log out the user using the D-BUS method call.
 /// The following D-BUS calls are attempted:
-/// - org.freedesktop.login1.Manager.Suspend(false)
+/// - org.xfce.SessionManager.Suspend()
+/// - org.freedesktop.login1.Manager.Suspend(true)
 /// - org.freedesktop.UPower.Suspend()
 /// - org.freedesktop.Hal.Device.SystemPowerManagement.Suspend()
 /// If nothing works up to this point, as a last resort this function calls `systemctl suspend`
 pub fn sleep() -> ShutdownResult {
-    if dbus_send("org.freedesktop.login1", "/org/freedesktop/login1", "org.freedesktop.login1.Manager",                                 "Suspend", &(false)) { return Ok(()); } // interactive - false
-    if dbus_send("org.freedesktop.UPower", "/org/freedesktop/UPower", "org.freedesktop.UPower",                                         "Suspend", &()) { return Ok(()); }
-    if dbus_send("org.freedesktop.Hal",    "/org/freedesktop/Hal/devices/computer", "org.freedesktop.Hal.Device.SystemPowerManagement", "Suspend", &()) { return Ok(()); }
+    if dbus_send("org.xfce.SessionManager", "/org/xfce/SessionManager",              "org.xfce.SessionManager",                          "Suspend", &())     { return Ok(()); }
+    if dbus_send("org.freedesktop.login1",  "/org/freedesktop/login1",               "org.freedesktop.login1.Manager",                   "Suspend", &(true)) { return Ok(()); } // interactive - true
+    if dbus_send("org.freedesktop.UPower",  "/org/freedesktop/UPower",               "org.freedesktop.UPower",                           "Suspend", &())     { return Ok(()); }
+    if dbus_send("org.freedesktop.Hal",     "/org/freedesktop/Hal/devices/computer", "org.freedesktop.Hal.Device.SystemPowerManagement", "Suspend", &())     { return Ok(()); }
 
     // As a last resort
     run_command("systemctl", &["suspend"])
@@ -148,14 +167,16 @@ pub fn sleep() -> ShutdownResult {
 
 /// Linux specific function to log out the user using the D-BUS method call.
 /// The following D-BUS calls are attempted:
-/// - org.freedesktop.login1.Manager.Hibernate(false)
+/// - org.xfce.SessionManager.Hibernate()
+/// - org.freedesktop.login1.Manager.Hibernate(true)
 /// - org.freedesktop.UPower.Hibernate()
 /// - org.freedesktop.Hal.Device.SystemPowerManagement.Hibernate()
 /// If nothing works up to this point, as a last resort this function calls `systemctl hibernate`
 pub fn hibernate() -> ShutdownResult {
-    if dbus_send("org.freedesktop.login1", "/org/freedesktop/login1", "org.freedesktop.login1.Manager",                                 "Hibernate", &(false)) { return Ok(()); } // interactive - false
-    if dbus_send("org.freedesktop.UPower", "/org/freedesktop/UPower", "org.freedesktop.UPower",                                         "Hibernate", &()) { return Ok(()); }
-    if dbus_send("org.freedesktop.Hal",    "/org/freedesktop/Hal/devices/computer", "org.freedesktop.Hal.Device.SystemPowerManagement", "Hibernate", &()) { return Ok(()); }
+    if dbus_send("org.xfce.SessionManager", "/org/xfce/SessionManager",              "org.xfce.SessionManager",                          "Hibernate", &())     { return Ok(()); }
+    if dbus_send("org.freedesktop.login1",  "/org/freedesktop/login1",               "org.freedesktop.login1.Manager",                   "Hibernate", &(true)) { return Ok(()); } // interactive - true
+    if dbus_send("org.freedesktop.UPower",  "/org/freedesktop/UPower",               "org.freedesktop.UPower",                           "Hibernate", &())     { return Ok(()); }
+    if dbus_send("org.freedesktop.Hal",     "/org/freedesktop/Hal/devices/computer", "org.freedesktop.Hal.Device.SystemPowerManagement", "Hibernate", &())     { return Ok(()); }
 
     // As a last resort
     run_command("systemctl", &["hibernate"])

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -51,7 +51,7 @@ fn get_session_id() -> String {
     session
 }
 
-/// Linux specific function to shut down the machine using the D-BUS method call.
+/// Linux specific function to shut down the machine using D-BUS method call.
 /// The following D-BUS calls are attempted:
 /// - org.gnome.SessionManager.Shutdown()
 /// - org.kde.KSMServerInterface.logout(-1, 2, 2)
@@ -83,7 +83,7 @@ pub fn force_shutdown() -> ShutdownResult {
     not_implemented!()
 }
 
-/// Linux specific function to reboot the machine using the D-BUS method call.
+/// Linux specific function to reboot the machine using D-BUS method call.
 /// The following D-BUS calls are attempted:
 /// - org.gnome.SessionManager.Reboot()
 /// - org.kde.KSMServerInterface.logout(-1, 1, 2)
@@ -120,7 +120,7 @@ pub fn force_reboot() -> ShutdownResult {
     Ok(())
 }
 
-/// Linux specific function to log out the user using the D-BUS method call.
+/// Linux specific function to log out the user using D-BUS method call.
 /// The following D-BUS calls are attempted:
 /// - org.gnome.SessionManager.Logout(1)
 /// - org.kde.KSMServerInterface.logout(-1, 0, 2)
@@ -148,7 +148,7 @@ pub fn force_logout() -> ShutdownResult {
     not_implemented!()
 }
 
-/// Linux specific function to log out the user using the D-BUS method call.
+/// Linux specific function to put the machine to sleep using D-BUS method call.
 /// The following D-BUS calls are attempted:
 /// - org.xfce.SessionManager.Suspend()
 /// - org.freedesktop.login1.Manager.Suspend(true)
@@ -165,7 +165,7 @@ pub fn sleep() -> ShutdownResult {
     run_command("systemctl", &["suspend"])
 }
 
-/// Linux specific function to log out the user using the D-BUS method call.
+/// Linux specific function to hibernate the machine using D-BUS method call.
 /// The following D-BUS calls are attempted:
 /// - org.xfce.SessionManager.Hibernate()
 /// - org.freedesktop.login1.Manager.Hibernate(true)

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -2,17 +2,33 @@ use std::fs::File;
 use std::io::{Error, ErrorKind, Write};
 use std::process::Command;
 
-use not_implemented;
-use ShutdownResult;
+use super::not_implemented;
+use super::ShutdownResult;
 
-fn perform_shutdown(rebooting: bool) -> ShutdownResult {
-    let mut cmd = Command::new("shutdown");
-    if rebooting {
-        cmd.arg("-r");
-    } else {
-        cmd.arg("-h");
+use zbus::export::serde::Serialize;
+use zbus::zvariant::DynamicType;
+
+fn name_has_owner(name: &str) -> bool {
+    if let Ok(conn) = zbus::blocking::Connection::session() {
+        let reply = conn.call_method(Some("org.freedesktop.DBus"), "/", Some("org.freedesktop.DBus"), "NameHasOwner", &(name));
+        return reply.and_then(|r| r.body()).unwrap_or(false);
     }
-    cmd.arg("now");
+    false
+}
+
+fn dbus_send<B: Serialize + DynamicType>(destination: &str, path: &str, interface: &str, method: &str, body: &B) -> bool {
+    if name_has_owner(destination) {
+        if let Ok(conn) = zbus::blocking::Connection::session() {
+            let reply = conn.call_method(Some(destination), path, Some(interface), method, body);
+            return reply.is_ok();
+        }
+    }
+    false
+}
+
+fn run_command(command: &str, args: &[&str]) -> ShutdownResult {
+    let mut cmd = Command::new(command);
+    cmd.args(args);
     match cmd.output() {
         Ok(output) => {
             if output.status.success() && output.stderr.is_empty() {
@@ -27,9 +43,33 @@ fn perform_shutdown(rebooting: bool) -> ShutdownResult {
     }
 }
 
-/// Linux specific function to shut down the machine using the `shutdown` command.
+fn get_session_id() -> String {
+    let mut session = std::fs::read_to_string("/proc/self/sessionid").unwrap_or_default().trim().to_string();
+    if session.is_empty() {
+        session = std::env::var("XDG_SESSION_ID").unwrap_or_default();
+    }
+    session
+}
+
+/// Linux specific function to shut down the machine using the D-BUS method call.
+/// The following D-BUS calls are attempted:
+/// - org.freedesktop.login1.Manager.PowerOff(false)
+/// - org.freedesktop.PowerManagement.Shutdown()
+/// - org.freedesktop.SessionManagement.Shutdown()
+/// - org.freedesktop.ConsoleKit.Manager.Stop()
+/// - org.freedesktop.Hal.Device.SystemPowerManagement.Shutdown()
+/// - org.gnome.SessionManager.Shutdown()
+/// If nothing works up to this point, as a last resort this function calls `shutdown -h now`
 pub fn shutdown() -> ShutdownResult {
-    perform_shutdown(false)
+    if dbus_send("org.freedesktop.login1",            "/org/freedesktop/login1",               "org.freedesktop.login1.Manager",                   "PowerOff", &(false)) { return Ok(()); } // interactive - false
+    if dbus_send("org.freedesktop.PowerManagement",   "/org/freedesktop/PowerManagement",      "org.freedesktop.PowerManagement",                  "Shutdown",  &()) { return Ok(()); }
+    if dbus_send("org.freedesktop.SessionManagement", "/org/freedesktop/SessionManagement",    "org.freedesktop.SessionManagement",                "Shutdown",  &()) { return Ok(()); }
+    if dbus_send("org.freedesktop.ConsoleKit",        "/org/freedesktop/ConsoleKit/Manager",   "org.freedesktop.ConsoleKit.Manager",               "Stop",     &()) { return Ok(()); }
+    if dbus_send("org.freedesktop.Hal",               "/org/freedesktop/Hal/devices/computer", "org.freedesktop.Hal.Device.SystemPowerManagement", "Shutdown", &()) { return Ok(()); }
+    if dbus_send("org.gnome.SessionManager",          "/org/gnome/SessionManager",             "org.gnome.SessionManager",                         "Shutdown", &()) { return Ok(()); }
+
+    // As a last resort
+    run_command("shutdown", &["-h", "now"])
 }
 
 #[doc(hidden)]
@@ -37,14 +77,30 @@ pub fn force_shutdown() -> ShutdownResult {
     not_implemented!()
 }
 
-/// Linux specific function to reboot the machine using the `shutdown` command.
+/// Linux specific function to reboot the machine using the D-BUS method call.
+/// The following D-BUS calls are attempted:
+/// - org.freedesktop.login1.Manager.Reboot(false)
+/// - org.freedesktop.PowerManagement.Reboot()
+/// - org.freedesktop.SessionManagement.Reboot()
+/// - org.freedesktop.ConsoleKit.Manager.Restart()
+/// - org.freedesktop.Hal.Device.SystemPowerManagement.Reboot()
+/// - org.gnome.SessionManager.Reboot()
+/// If nothing works up to this point, as a last resort this function calls `shutdown -r now`
 pub fn reboot() -> ShutdownResult {
-    perform_shutdown(true)
+    if dbus_send("org.freedesktop.login1",            "/org/freedesktop/login1",               "org.freedesktop.login1.Manager",                   "Reboot",  &(false)) { return Ok(()); } // interactive - false
+    if dbus_send("org.freedesktop.PowerManagement",   "/org/freedesktop/PowerManagement",      "org.freedesktop.PowerManagement",                  "Reboot",  &()) { return Ok(()); }
+    if dbus_send("org.freedesktop.SessionManagement", "/org/freedesktop/SessionManagement",    "org.freedesktop.SessionManagement",                "Reboot",  &()) { return Ok(()); }
+    if dbus_send("org.freedesktop.ConsoleKit",        "/org/freedesktop/ConsoleKit/Manager",   "org.freedesktop.ConsoleKit.Manager",               "Restart", &()) { return Ok(()); }
+    if dbus_send("org.freedesktop.Hal",               "/org/freedesktop/Hal/devices/computer", "org.freedesktop.Hal.Device.SystemPowerManagement", "Reboot",  &()) { return Ok(()); }
+    if dbus_send("org.gnome.SessionManager",          "/org/gnome/SessionManager",             "org.gnome.SessionManager",                         "Reboot",  &()) { return Ok(()); }
+
+    // As a last resort
+    run_command("shutdown", &["-r", "now"])
 }
 
 /// Linux specific function to force reboot the machine using the magic SysRq key.
+/// Reference: https://www.kernel.org/doc/html/latest/admin-guide/sysrq.html
 pub fn force_reboot() -> ShutdownResult {
-    // Reference: https://www.kernel.org/doc/html/latest/admin-guide/sysrq.html
     let mut file = File::create("/proc/sys/kernel/sysrq")?;
     file.write_all(b"128")?;
     file = File::create("/proc/sysrq-trigger")?;
@@ -52,12 +108,55 @@ pub fn force_reboot() -> ShutdownResult {
     Ok(())
 }
 
-#[doc(hidden)]
+/// Linux specific function to log out the user using the D-BUS method call.
+/// The following D-BUS calls are attempted:
+/// - org.freedesktop.login1.Manager.TerminateSession(session_id)
+/// - org.gnome.SessionManager.Logout(1)
+/// - org.kde.KSMServerInterface.closeSession()
+/// If nothing works up to this point, as a last resort this function calls `loginctl kill-session $XDG_SESSION_ID`
 pub fn logout() -> ShutdownResult {
-    not_implemented!()
+    let session_id = get_session_id();
+    if !session_id.is_empty() {
+        if dbus_send("org.freedesktop.login1",    "/org/freedesktop/login1",    "org.freedesktop.login1.Manager", "TerminateSession", &(session_id)) { return Ok(()); }
+    }
+    if dbus_send("org.gnome.SessionManager",  "/org/gnome/SessionManager",  "org.gnome.SessionManager",       "Logout",           &(1)) { return Ok(()); } // 1 - no confirmation dialog, 2 - force logout
+    if dbus_send("org.kde.ksmserver",         "/KSMServer",                 "org.kde.KSMServerInterface",     "closeSession",     &())  { return Ok(()); }
+
+    // As a last resort
+    run_command("loginctl", &["kill-session", &session_id])
 }
 
 #[doc(hidden)]
 pub fn force_logout() -> ShutdownResult {
     not_implemented!()
+}
+
+/// Linux specific function to log out the user using the D-BUS method call.
+/// The following D-BUS calls are attempted:
+/// - org.freedesktop.login1.Manager.Suspend(false)
+/// - org.freedesktop.UPower.Suspend()
+/// - org.freedesktop.Hal.Device.SystemPowerManagement.Suspend()
+/// If nothing works up to this point, as a last resort this function calls `systemctl suspend`
+pub fn sleep() -> ShutdownResult {
+    if dbus_send("org.freedesktop.login1", "/org/freedesktop/login1", "org.freedesktop.login1.Manager",                                 "Suspend", &(false)) { return Ok(()); } // interactive - false
+    if dbus_send("org.freedesktop.UPower", "/org/freedesktop/UPower", "org.freedesktop.UPower",                                         "Suspend", &()) { return Ok(()); }
+    if dbus_send("org.freedesktop.Hal",    "/org/freedesktop/Hal/devices/computer", "org.freedesktop.Hal.Device.SystemPowerManagement", "Suspend", &()) { return Ok(()); }
+
+    // As a last resort
+    run_command("systemctl", &["suspend"])
+}
+
+/// Linux specific function to log out the user using the D-BUS method call.
+/// The following D-BUS calls are attempted:
+/// - org.freedesktop.login1.Manager.Hibernate(false)
+/// - org.freedesktop.UPower.Hibernate()
+/// - org.freedesktop.Hal.Device.SystemPowerManagement.Hibernate()
+/// If nothing works up to this point, as a last resort this function calls `systemctl hibernate`
+pub fn hibernate() -> ShutdownResult {
+    if dbus_send("org.freedesktop.login1", "/org/freedesktop/login1", "org.freedesktop.login1.Manager",                                 "Hibernate", &(false)) { return Ok(()); } // interactive - false
+    if dbus_send("org.freedesktop.UPower", "/org/freedesktop/UPower", "org.freedesktop.UPower",                                         "Hibernate", &()) { return Ok(()); }
+    if dbus_send("org.freedesktop.Hal",    "/org/freedesktop/Hal/devices/computer", "org.freedesktop.Hal.Device.SystemPowerManagement", "Hibernate", &()) { return Ok(()); }
+
+    // As a last resort
+    run_command("systemctl", &["hibernate"])
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -24,9 +24,9 @@ fn invoke_script(script: &str) -> ShutdownResult {
 
 /// MacOS requires to explicitly allow the application to call "System Events". If you want to use this crate in an unattended way (automation etc.),
 /// you may want to ask for permission beforehand to allow this app to call "System Events".
-/// This function requests the "System Events" to press the Shift key, which should be a fairly safe operation.
+/// This function requests the "System Events" to "stop current screen saver", which should be a fairly safe operation.
 pub fn request_permission_dialog() -> ShutdownResult {
-    invoke_script("tell application \"System Events\" to keystroke key code 16")
+    invoke_script("tell application \"System Events\" to stop current screen saver")
 }
 
 /// MacOS specific function to reboot without showing a confirmation dialog using AppleScript and "System Events" call "shut down"

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -29,7 +29,7 @@ pub fn request_permission_dialog() -> ShutdownResult {
     invoke_script("tell application \"System Events\" to stop current screen saver")
 }
 
-/// MacOS specific function to reboot without showing a confirmation dialog using AppleScript and "System Events" call "shut down"
+/// MacOS specific function to shut down the system using AppleScript and "System Events" call "shut down"
 /// First time you use this, MacOS will ask for a permission. If you want to ask for a permission beforehand, use [`request_permission_dialog`]
 pub fn shutdown() -> ShutdownResult {
     invoke_script("tell application \"System Events\" to shut down")
@@ -40,7 +40,7 @@ pub fn force_shutdown() -> ShutdownResult {
     not_implemented!()
 }
 
-/// MacOS specific function to reboot without showing a confirmation dialog using AppleScript and "System Events" call "restart"
+/// MacOS specific function to reboot using AppleScript and "System Events" call "restart"
 /// First time you use this, MacOS will ask for a permission. If you want to ask for a permission beforehand, use [`request_permission_dialog`]
 pub fn reboot() -> ShutdownResult {
     invoke_script("tell application \"System Events\" to restart")

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,0 +1,80 @@
+use std::fs::File;
+use std::io::{Error, ErrorKind, Write};
+use std::process::Command;
+
+use super::not_implemented;
+use super::ShutdownResult;
+
+fn invoke_script(script: &str) -> ShutdownResult {
+    let mut cmd = Command::new("osascript");
+    cmd.args(&["-e", script]);
+    match cmd.output() {
+        Ok(output) => {
+            if output.status.success() && output.stderr.is_empty() {
+                return Ok(());
+            }
+            Err(Error::new(
+                ErrorKind::Other,
+                String::from_utf8(output.stderr).unwrap(),
+            ))
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// MacOS requires to explicitly allow the application to call "System Events". If you want to use this crate in an unattended way (automation etc.),
+/// you may want to ask for permission beforehand to allow this app to call "System Events".
+/// This function requests the "System Events" to press the Shift key, which should be a fairly safe operation.
+pub fn request_permission_dialog() -> ShutdownResult {
+    invoke_script("tell application \"System Events\" to keystroke key code 16")
+}
+
+/// MacOS specific function to reboot without showing a confirmation dialog using AppleScript and "System Events" call "shut down"
+/// First time you use this, MacOS will ask for a permission. If you want to ask for a permission beforehand, use [`request_permission_dialog`]
+pub fn shutdown() -> ShutdownResult {
+    invoke_script("tell application \"System Events\" to shut down")
+}
+
+#[doc(hidden)]
+pub fn force_shutdown() -> ShutdownResult {
+    not_implemented!()
+}
+
+/// MacOS specific function to reboot without showing a confirmation dialog using AppleScript and "System Events" call "restart"
+/// First time you use this, MacOS will ask for a permission. If you want to ask for a permission beforehand, use [`request_permission_dialog`]
+pub fn reboot() -> ShutdownResult {
+    invoke_script("tell application \"System Events\" to restart")
+}
+
+/// Unix specific function to force reboot the machine using the magic SysRq key.
+pub fn force_reboot() -> ShutdownResult {
+    // Reference: https://www.kernel.org/doc/html/latest/admin-guide/sysrq.html
+    let mut file = File::create("/proc/sys/kernel/sysrq")?;
+    file.write_all(b"128")?;
+    file = File::create("/proc/sysrq-trigger")?;
+    file.write_all(b"b")?;
+    Ok(())
+}
+
+/// MacOS specific function to logout with a confirmation dialog using AppleScript and "System Events" call "log out".
+/// First time you use this, MacOS will ask for a permission. If you want to ask for a permission beforehand, use [`request_permission_dialog`]
+pub fn logout() -> ShutdownResult {
+    invoke_script("tell application \"System Events\" to log out")
+}
+
+/// MacOS specific function to force logout without showing a confirmation dialog using AppleScript and "loginwindow" call "«event aevtrlgo»"
+pub fn force_logout() -> ShutdownResult {
+    invoke_script("tell application \"loginwindow\" to «event aevtrlgo»")
+}
+
+/// MacOS specific function to put the machine to sleep using AppleScript and "System Events" call "sleep"
+/// First time you use this, MacOS will ask for a permission. If you want to ask for a permission beforehand, use [`request_permission_dialog`]
+pub fn sleep() -> ShutdownResult {
+    invoke_script("tell application \"System Events\" to sleep")
+}
+
+#[doc(hidden)]
+pub fn hibernate() -> ShutdownResult {
+    // It's possible but not generally a good idea https://superuser.com/a/630985
+    not_implemented!()
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,25 +1,28 @@
-use std::ffi::OsStr;
 use std::io::Error;
-use std::iter::once;
 use std::mem;
-use std::os::windows::ffi::OsStrExt;
 use std::ptr;
-use winapi::shared::minwindef::{FALSE, UINT};
-use winapi::um::processthreadsapi::{GetCurrentProcess, OpenProcessToken};
-use winapi::um::reason::{
-    SHTDN_REASON_FLAG_PLANNED, SHTDN_REASON_MAJOR_OPERATINGSYSTEM, SHTDN_REASON_MINOR_UPGRADE,
-};
-use winapi::um::securitybaseapi::AdjustTokenPrivileges;
-use winapi::um::winbase::LookupPrivilegeValueW;
-use winapi::um::winnt::{
-    HANDLE, LPWSTR, SE_PRIVILEGE_ENABLED, SE_SHUTDOWN_NAME, TOKEN_ADJUST_PRIVILEGES,
-    TOKEN_PRIVILEGES, TOKEN_QUERY,
-};
-use winapi::um::winuser::{
-    ExitWindowsEx, EWX_FORCE, EWX_FORCEIFHUNG, EWX_LOGOFF, EWX_REBOOT, EWX_SHUTDOWN,
+use windows::{
+    core::{PCWSTR, HSTRING},
+    Win32::{
+        Foundation::{HANDLE, BOOLEAN},
+        System::{
+            Threading::{GetCurrentProcess, OpenProcessToken},
+            SystemServices::SE_SHUTDOWN_NAME,
+            Power::SetSuspendState,
+            Shutdown::{
+                ExitWindowsEx, InitiateSystemShutdownW, EWX_LOGOFF, EWX_REBOOT, EWX_SHUTDOWN,
+                SHTDN_REASON_FLAG_PLANNED, SHTDN_REASON_MAJOR_OPERATINGSYSTEM, SHTDN_REASON_MINOR_UPGRADE, EXIT_WINDOWS_FLAGS
+            }
+        },
+        Security::{
+            LookupPrivilegeValueW, AdjustTokenPrivileges, SE_PRIVILEGE_ENABLED, TOKEN_ADJUST_PRIVILEGES,
+            TOKEN_PRIVILEGES, TOKEN_QUERY,
+        },
+        UI::WindowsAndMessaging::{EWX_FORCE, EWX_FORCEIFHUNG}
+    }
 };
 
-use ShutdownResult;
+use super::ShutdownResult;
 
 #[doc(hidden)]
 #[macro_export]
@@ -31,81 +34,103 @@ macro_rules! last_os_error {
 
 fn request_privileges() -> ShutdownResult {
     unsafe {
-        let mut token: HANDLE = ptr::null_mut();
+        let mut token: HANDLE = HANDLE::default();
         let mut tkp: TOKEN_PRIVILEGES = mem::zeroed();
-        if OpenProcessToken(
-            GetCurrentProcess(),
-            TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
-            &mut token,
-        ) == FALSE
-        {
+        if !OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &mut token).as_bool() {
             return last_os_error!();
         }
-        let security_name: Vec<u16> = OsStr::new(SE_SHUTDOWN_NAME)
-            .encode_wide()
-            .chain(once(0))
-            .collect();
-        if LookupPrivilegeValueW(
-            ptr::null(),
-            security_name.as_ptr() as LPWSTR,
-            &mut tkp.Privileges[0].Luid,
-        ) == FALSE
-        {
+        if !LookupPrivilegeValueW(PCWSTR::null(), PCWSTR::from(&HSTRING::from(SE_SHUTDOWN_NAME)), &mut tkp.Privileges[0].Luid).as_bool() {
             return last_os_error!();
         }
         tkp.PrivilegeCount = 1;
         tkp.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
-        if AdjustTokenPrivileges(token, FALSE, &mut tkp, 0, ptr::null_mut(), ptr::null_mut())
-            == FALSE
-        {
+        if !AdjustTokenPrivileges(token, false, &mut tkp, 0, ptr::null_mut(), ptr::null_mut()).as_bool() {
             return last_os_error!();
         }
     }
     Ok(())
 }
 
-fn exit_windows(flag: UINT) -> ShutdownResult {
+fn exit_windows(flag: u32) -> ShutdownResult {
     unsafe {
         request_privileges()?;
-        if ExitWindowsEx(
-            flag | EWX_FORCEIFHUNG,
-            SHTDN_REASON_MAJOR_OPERATINGSYSTEM
-                | SHTDN_REASON_MINOR_UPGRADE
-                | SHTDN_REASON_FLAG_PLANNED,
-        ) == FALSE
+        if !ExitWindowsEx(
+            EXIT_WINDOWS_FLAGS(flag | EWX_FORCEIFHUNG),
+            SHTDN_REASON_MAJOR_OPERATINGSYSTEM | SHTDN_REASON_MINOR_UPGRADE | SHTDN_REASON_FLAG_PLANNED
+        ).as_bool()
         {
             return last_os_error!();
         }
     }
     Ok(())
+}
+fn initiate_system_shutdown(message: &str, timeout: u32, force_close_apps: bool, restart: bool) -> ShutdownResult {
+    unsafe {
+        request_privileges()?;
+        if !InitiateSystemShutdownW(PCWSTR::null(), PCWSTR::from(&HSTRING::from(message)), timeout, force_close_apps, restart).as_bool() {
+            return last_os_error!();
+        }
+    }
+    Ok(())
+}
+fn set_suspend_state(hibernate: bool) -> ShutdownResult {
+    unsafe {
+        request_privileges()?;
+        if SetSuspendState(BOOLEAN(if hibernate { 1 } else { 0 }), BOOLEAN(0), BOOLEAN(0)).0 == 0 {
+            return last_os_error!();
+        }
+    }
+    Ok(())
+}
+
+/// Windows specific function to gracefully request system shutdown, providing a way to show a message,
+/// set a timeout and specify if apps should be force-closed
+pub fn shutdown_with_message(message: &str, timeout: u32, force_close_apps: bool) -> ShutdownResult {
+    initiate_system_shutdown(message, timeout, force_close_apps, false)
+}
+
+/// Windows specific function to gracefully request system reboot, providing a way to show a message,
+/// set a timeout and specify if apps should be force-closed
+pub fn reboot_with_message(message: &str, timeout: u32, force_close_apps: bool) -> ShutdownResult {
+    initiate_system_shutdown(message, timeout, force_close_apps, true)
 }
 
 /// Windows specific function to shut down the machine using the `ExitWindowsEx()` from `winuser` API.
 pub fn shutdown() -> ShutdownResult {
-    exit_windows(EWX_SHUTDOWN)
+    exit_windows(EWX_SHUTDOWN.0)
 }
 
 /// Windows specific function to shut down the machine instantly without confirmations using the `ExitWindowsEx()` from `winuser` API.
 pub fn force_shutdown() -> ShutdownResult {
-    exit_windows(EWX_SHUTDOWN | EWX_FORCE)
+    exit_windows(EWX_SHUTDOWN.0 | EWX_FORCE)
 }
 
 /// Windows specific function to reboot the machine using the `ExitWindowsEx()` from `winuser` API.
 pub fn reboot() -> ShutdownResult {
-    exit_windows(EWX_REBOOT)
+    exit_windows(EWX_REBOOT.0)
 }
 
 /// Windows specific function to reboot the machine instantly without confirmations using the `ExitWindowsEx()` from `winuser` API.
 pub fn force_reboot() -> ShutdownResult {
-    exit_windows(EWX_REBOOT | EWX_FORCE)
+    exit_windows(EWX_REBOOT.0 | EWX_FORCE)
 }
 
 /// Windows specific function to log out the user using the `ExitWindowsEx()` from `winuser` API.
 pub fn logout() -> ShutdownResult {
-    exit_windows(EWX_LOGOFF)
+    exit_windows(EWX_LOGOFF.0)
 }
 
 /// Windows specific function to log out the user instantly without confirmations using the `ExitWindowsEx()` from `winuser` API.
 pub fn force_logout() -> ShutdownResult {
-    exit_windows(EWX_LOGOFF | EWX_FORCE)
+    exit_windows(EWX_LOGOFF.0 | EWX_FORCE)
+}
+
+/// Windows specific function to put the machine to sleep using `SetSuspendState()` API call.
+pub fn sleep() -> ShutdownResult {
+    set_suspend_state(false)
+}
+
+/// Windows specific function to hibernate the machine using `SetSuspendState()` API call.
+pub fn hibernate() -> ShutdownResult {
+    set_suspend_state(true)
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -44,7 +44,7 @@ fn request_privileges() -> ShutdownResult {
         }
         tkp.PrivilegeCount = 1;
         tkp.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
-        if !AdjustTokenPrivileges(token, false, &mut tkp, 0, ptr::null_mut(), ptr::null_mut()).as_bool() {
+        if !AdjustTokenPrivileges(token, false, Some(&tkp), None, None).as_bool() {
             return last_os_error!();
         }
     }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,6 +1,5 @@
 use std::io::Error;
 use std::mem;
-use std::ptr;
 use windows::{
     core::{PCWSTR, HSTRING},
     Win32::{
@@ -44,7 +43,7 @@ fn request_privileges() -> ShutdownResult {
         }
         tkp.PrivilegeCount = 1;
         tkp.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
-        if !AdjustTokenPrivileges(token, false, Some(&tkp), None, None).as_bool() {
+        if !AdjustTokenPrivileges(token, false, Some(&tkp), 0, None, None).as_bool() {
             return last_os_error!();
         }
     }


### PR DESCRIPTION
- Updated all dependencies and edition to 2021
- Removed obsolete `extern crate`
- Added `sleep` and `hibernate` functions
- Added proper Linux D-BUS calls
- Added proper MacOS requests via `osascript`

Tested on Windows, macOS, and Linux: Debian/Ubuntu/Arch with GNOME/KDE/xfce4/MATE/Cinnamon

I added method docs in system-specific files, not sure how it'll get rendered for the main crate. If you could check that it would be great

