### PR TITLE
Replace String::from_utf8().unwrap() with from_utf8_lossy()

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -59,7 +59,7 @@ fn run_command(command: &str, args: &[&str]) -> ShutdownResult {
             }
             Err(Error::new(
                 ErrorKind::Other,
-                String::from_utf8(output.stderr).unwrap(),
+                String::from_utf8_lossy(&output.stderr).into_owned(),
             ))
         }
         Err(error) => Err(error),

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -15,7 +15,7 @@ fn invoke_script(script: &str) -> ShutdownResult {
             }
             Err(Error::new(
                 ErrorKind::Other,
-                String::from_utf8(output.stderr).unwrap(),
+                String::from_utf8_lossy(&output.stderr).into_owned(),
             ))
         }
         Err(error) => Err(error),


### PR DESCRIPTION
## Summary

`invoke_script()` (macOS) and `run_command()` (Linux) use `String::from_utf8(output.stderr).unwrap()` which panics if stderr contains non-UTF-8 bytes. Replaced with `String::from_utf8_lossy()` which safely handles invalid sequences.

Closes #19

## Test plan

- [x] `cargo check --target aarch64-apple-darwin` passes