### PR TITLE
Add empty session_id guard in logout() fallback

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -337,16 +337,21 @@ pub fn logout() -> ShutdownResult {
     } // show_dialog - true, allow_save - true
 
     let session_id = get_session_id();
-    if !session_id.is_empty() {
-        if dbus_send(
-            "org.freedesktop.login1",
-            "/org/freedesktop/login1",
-            "org.freedesktop.login1.Manager",
-            "TerminateSession",
-            &(session_id),
-        ) {
-            return Ok(());
-        }
+    if session_id.is_empty() {
+        return Err(Error::new(
+            ErrorKind::Other,
+            "could not determine session ID for logout",
+        ));
+    }
+
+    if dbus_send(
+        "org.freedesktop.login1",
+        "/org/freedesktop/login1",
+        "org.freedesktop.login1.Manager",
+        "TerminateSession",
+        &session_id,
+    ) {
+        return Ok(());
     }
 
     // As a last resort


### PR DESCRIPTION
## Summary

When `get_session_id()` returns an empty string, `logout()` skips the D-Bus `TerminateSession` call but still falls through to `loginctl kill-session ""`, which always fails. Added an early return with a clear error message when `session_id` is empty.

Closes #21

## Test plan

- [x] `cargo check --target aarch64-apple-darwin` passes
- [ ] CI validation on Linux target